### PR TITLE
Telegram bug bash: add user handling so that /gex and /linden are less broken

### DIFF
--- a/steely/plugins/_gex_util.py
+++ b/steely/plugins/_gex_util.py
@@ -21,10 +21,14 @@ def user_id_to_name(bot, user_id):
     if user_id in ID_TO_NAME:
         return ID_TO_NAME[user_id]
     try:
-        user = bot.fetchUserInfo(user_id)[user_id]
-        ID_TO_NAME[user_id] = user.name
-        return user.name
-    except Exception:
+        users = bot.fetchUserInfo(user_id)
+        if len(users) == 0:
+            raise ValueError('No user found for ID {}'.format(user_id))
+        ID_TO_NAME[user_id] = users[0]['full_name']
+        return users[0]['full_name']
+    except Exception as e:
+        print('Error in user_id_to_name:')
+        print(e)
         return 'Zucc'
 
 

--- a/steely/plugins/linden.py
+++ b/steely/plugins/linden.py
@@ -189,7 +189,7 @@ def get_balance(user_id):
     matching_users = USERDB.search(USER.id == user_id)
     if len(matching_users) == 0:
         return
-    return matching_users['lindens']
+    return matching_users[0]['lindens']
 
 
 def give_cmd(bot, message_parts, author_id, thread_id, thread_type):

--- a/steely/plugins/linden.py
+++ b/steely/plugins/linden.py
@@ -122,14 +122,20 @@ TICKER_FETCHERS = [
 
 def user_from_name(name, list):
     for user in list:
-        if user.first_name == name:
+        if user['first_name'] == name:
             return user
 
 
 def list_users(bot, thread_id):
-    group = bot.fetchGroupInfo(thread_id)[thread_id]
-    user_ids = group.participants
-    yield from bot.fetchUserInfo(*user_ids).values()
+    groups = bot.fetchGroupInfo(thread_id)
+    if len(groups) == 0:
+        return
+    user_ids = groups[0]['users']
+    for user_id in user_ids:
+        matching_users = bot.fetchUserInfo(user_id)
+        if len(matching_users) == 0:
+            continue
+        yield matching_users[0]
 
 
 def create_user(id, first_name):

--- a/steely/plugins/linden.py
+++ b/steely/plugins/linden.py
@@ -180,7 +180,7 @@ def handle_gex_sell_cards(user_id, ticker, profit):
 
 
 def get_balance(user_id):
-    matching_users = USERDB.get(USER.id == user_id)
+    matching_users = USERDB.search(USER.id == user_id)
     if len(matching_users) == 0:
         return
     return matching_users['lindens']
@@ -461,7 +461,12 @@ SUBCOMMANDS = {
 def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     REED_ID = bot.uid
     if not message:
-        bot.sendMessage('you have {:.4f} Linden Dollars™'.format(get_balance(author_id)),
+        balance = get_balance(author_id)
+        if balance is None:
+            bot.sendMessage('you have no account, loser',
+                            thread_id=thread_id, thread_type=thread_type)
+            return
+        bot.sendMessage('you have {:.4f} Linden Dollars™'.format(balance),
                         thread_id=thread_id, thread_type=thread_type)
         return
 

--- a/steely/plugins/linden.py
+++ b/steely/plugins/linden.py
@@ -201,14 +201,14 @@ def give_cmd(bot, message_parts, author_id, thread_id, thread_type):
     reciever_name, amount = message_parts[0].lstrip(
         "@").capitalize(), int(message_parts[-1])
     reciever_model = user_from_name(reciever_name, users)
-    reciever = USERDB.get(USER.id == reciever_model.uid)
-    sender_model = bot.fetchUserInfo(author_id)[author_id]
+    reciever = USERDB.get(USER.id == reciever_model['id'])
+    sender_model = bot.fetchUserInfo(author_id)[0]
     sender = USERDB.get(USER.id == author_id)
-    if sender_model.uid == reciever_model.uid:
+    if sender_model['id'] == reciever_model['id']:
         bot.sendMessage('no', thread_id=thread_id, thread_type=thread_type)
         return
     if not reciever:
-        reciever = create_user(reciever_model.uid, reciever_model.first_name)
+        reciever = create_user(reciever_model['id'], reciever_model.first_name)
     if not sender:
         sender = create_user(author_id, sender_model.first_name)
     new_sender_balance = sender['lindens'] - amount
@@ -218,7 +218,7 @@ def give_cmd(bot, message_parts, author_id, thread_id, thread_type):
         return
     USERDB.update({'lindens': new_sender_balance}, USER.id == author_id)
     USERDB.update(
-        {'lindens': reciever['lindens'] + amount}, USER.id == reciever_model.uid)
+        {'lindens': reciever['lindens'] + amount}, USER.id == reciever_model['id'])
     bot.sendMessage('you gave {} {} Linden Dollars™'.format(reciever_name, amount),
                     thread_id=thread_id, thread_type=thread_type)
 

--- a/steely/plugins/linden.py
+++ b/steely/plugins/linden.py
@@ -208,9 +208,9 @@ def give_cmd(bot, message_parts, author_id, thread_id, thread_type):
         bot.sendMessage('no', thread_id=thread_id, thread_type=thread_type)
         return
     if not reciever:
-        reciever = create_user(reciever_model['id'], reciever_model.first_name)
+        reciever = create_user(reciever_model['id'], reciever_model['first_name'])
     if not sender:
-        sender = create_user(author_id, sender_model.first_name)
+        sender = create_user(author_id, sender_model['first_name'])
     new_sender_balance = sender['lindens'] - amount
     if new_sender_balance < 0:
         bot.sendMessage('you\'d be broke boyo',

--- a/steely/plugins/markov.py
+++ b/steely/plugins/markov.py
@@ -24,7 +24,7 @@ def should_reply():
 
 
 def generate_reply(thread_id, thread_type):
-    log_path = os.path.join(LOGFOLDER, thread_type.name, thread_id)
+    log_path = os.path.join(LOGFOLDER, thread_type.name, str(thread_id))
     with open(log_path, 'r') as file_:
         log_model = markovify.NewlineText(file_.read())
         new_sentence = log_model.make_sentence(tries=100)

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -90,8 +90,6 @@ class SteelyBot(Client):
         self.friendConnect(from_id)
 
     def onMessage(self, author_id, message, thread_id, thread_type, **kwargs):
-        self.markAsDelivered(author_id, thread_id)
-        self.markAsRead(author_id)
         if author_id == self.uid:
             return
         self.run_non_plugins(author_id, message, thread_id,

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -26,6 +26,8 @@ literal commands can be mandatory or optional'''
 
 
 class SteelyBot(Client):
+    '''Wraps around the Telegram Fbchat facade and handles Steely-specific stuff,
+    ie. plugins.'''
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -77,11 +77,6 @@ class SteelyBot(Client):
             thread.deamon = True
             thread.start()
 
-    def onEmojiChange(self, author_id, new_emoji, thread_id, thread_type, **kwargs):
-        nose = '👃'
-        if new_emoji != nose:
-            self.changeThreadEmoji(nose, thread_id=thread_id)
-
     def onNicknameChange(self, mid, author_id, changed_for, new_nickname, thread_id, thread_type, ts, metadata, msg):
         self.changeNickname(vapor(new_nickname), user_id=changed_for,
                             thread_id=thread_id, thread_type=thread_type)

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -77,13 +77,6 @@ class SteelyBot(Client):
             thread.deamon = True
             thread.start()
 
-    def onNicknameChange(self, mid, author_id, changed_for, new_nickname, thread_id, thread_type, ts, metadata, msg):
-        self.changeNickname(vapor(new_nickname), user_id=changed_for,
-                            thread_id=thread_id, thread_type=thread_type)
-
-    def onFriendRequest(self, from_id, msg):
-        self.friendConnect(from_id)
-
     def onMessage(self, author_id, message, thread_id, thread_type, **kwargs):
         if author_id == self.uid:
             return

--- a/steely/telegram_fbchat_facade.py
+++ b/steely/telegram_fbchat_facade.py
@@ -79,14 +79,6 @@ class Client:
         except Exception as e:
             log(e)
 
-    def markAsDelivered(self, *args, **kwargs):
-        '''TODO: Remove this method, it's only here to suppress errors.'''
-        pass
-
-    def markAsRead(self, *args, **kwargs):
-        '''TODO: Remove this method, it's only here to suppress errors.'''
-        pass
-
     def onEmojiChange(self, author_id, new_emoji,
                       thread_id, thread_type, **kwargs):
         '''Handler method; to be overriden.'''

--- a/steely/telegram_fbchat_facade.py
+++ b/steely/telegram_fbchat_facade.py
@@ -1,3 +1,4 @@
+import json
 from collections import defaultdict, deque
 from enum import Enum
 
@@ -78,15 +79,6 @@ class Client:
                                photo=image)
         except Exception as e:
             log(e)
-
-    def onNicknameChange(self, mid, author_id, changed_for, new_nickname,
-                         thread_id, thread_type, ts, metadata, msg):
-        '''Handler method; to be overriden.'''
-        pass
-
-    def onFriendRequest(self, from_id, msg):
-        '''Handler method; to be overriden.'''
-        pass
 
     def onMessage(self, author_id, message, thread_id, thread_type, **kwargs):
         '''Handler method; to be overriden.'''

--- a/steely/telegram_fbchat_facade.py
+++ b/steely/telegram_fbchat_facade.py
@@ -105,5 +105,17 @@ class Client:
         '''Handler method; to be overriden.'''
         pass
 
+    def fetchUserInfo(self, *user_ids):
+        '''Gets info about the given user(s).'''
+        raise NotImplementedError('fetchUserInfo not implemented')
+
+    def fetchGroupInfo(self, *thread_ids):
+        '''Gets info about the given group(s).'''
+        raise NotImplementedError('fetchGroupInfo not implemented')
+
+    def searchForUsers(self, name, limit=10):
+        '''Finds users by their display name.'''
+        raise NotImplementedError('searchForUsers not implemented')
+
 def log(*args, **kwargs):
     print("log:", *args, *kwargs)

--- a/steely/telegram_fbchat_facade.py
+++ b/steely/telegram_fbchat_facade.py
@@ -79,11 +79,6 @@ class Client:
         except Exception as e:
             log(e)
 
-    def onEmojiChange(self, author_id, new_emoji,
-                      thread_id, thread_type, **kwargs):
-        '''Handler method; to be overriden.'''
-        pass
-
     def onNicknameChange(self, mid, author_id, changed_for, new_nickname,
                          thread_id, thread_type, ts, metadata, msg):
         '''Handler method; to be overriden.'''


### PR DESCRIPTION
Blurb:
/gex and /linden might even work now, idk; I think /linden just needs some initial user to trigger everything, and /linden just needs the database to populate with user_id -> name mappings (+ the search user by name func is required).
The markov plugin also has a small change here to suppress an error.
Some facebook-only stuff (eg. emoji) is removed.

Details:
Using "thread" to mean "channel"/"group chat"/etc.:
Everyone's favourite stock market gambling plugin is built around user_id <-> name stuff, so we require a way to do [user ID, user real name, thread] admin.
Telegram doesn't allow (right now) arbitrary querying of users by ID. They only allow querying a combo of (thread_id, user_id). Telegram also doesn't allow querying all users in a given thread. To support these functions, I added a SteelyUserManager that tracks all the users as they say things. 
This is a first impl, a better one would be nice later once this is merged & stable.