### PR TITLE
Telegram bug bash: fix /np milestone, /np collage, /np[@steelybot]

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ nosetest
 
 If the tests are failing to import, you probably aren't in the virtualenv.
 
-## how to write help for you commands
+## how to write help for your commands
 
 Throw a doc string in the top of the plugin.
 

--- a/steely/plugins/_gex_util.py
+++ b/steely/plugins/_gex_util.py
@@ -13,12 +13,15 @@ ID_TO_NAME = {}
 
 
 def user_name_to_id(bot, name):
+    print('user_name_to_id(bot, {})'.format(name))
     users = bot.searchForUsers(name)
-    return users[0].uid
+    print("Searched for", name, "got", users)
+    return users['id']
 
 
 def user_id_to_name(bot, user_id):
     if user_id in ID_TO_NAME:
+        print('Cache hit for {} in user_id_to_name'.format(user_id))
         return ID_TO_NAME[user_id]
     try:
         users = bot.fetchUserInfo(user_id)

--- a/steely/plugins/_lastfm_milestone.py
+++ b/steely/plugins/_lastfm_milestone.py
@@ -32,10 +32,10 @@ def main(bot, author_id, message_parts, thread_id, thread_type, **kwargs):
         bot.sendMessage(f'include username please or use {COMMAND} set',
                         thread_id=thread_id, thread_type=thread_type)
         return
-    scrobbles = get_lastfm_request("user.getInfo",
+    scrobbles = int(get_lastfm_request("user.getInfo",
                                    user=username) \
                     .json() \
-                    ['user']['playcount']
+                    ['user']['playcount'])
     distance, milestone = get_distance_and_milestone(scrobbles)
     bot.sendMessage(f"{username} is {distance:,} scrobbles away from their next milestone of *{milestone:,}*",
                     thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/gex.py
+++ b/steely/plugins/gex.py
@@ -248,8 +248,11 @@ def _gex_give(bot, args, author_id, thread_id, thread_type):
     if not args or len(args) != 2:
         raise RuntimeError(
             'Need to provide command in the form give USER CARD_ID .')
+    print('args = ', args)
     user_id = gex_util.user_name_to_id(bot, args[0])
+    print('got user_id', user_id)
     card_id = args[1]
+    print('gex_give({}, {}, {})'.format(author_id, card_id, user_id))
     gex_give(author_id, card_id, user_id)
     # TODO(iandioch): Notify user they got a new card.
 

--- a/steely/plugins/recordstat.py
+++ b/steely/plugins/recordstat.py
@@ -25,7 +25,7 @@ def is_tilda_command(command):
 
 
 def looks_like_command(command):
-    identifiers = '.', '~'
+    identifiers = '.', '~', '/'
     return any(command.startswith(char) for char in identifiers)
 
 

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -56,7 +56,7 @@ class SteelyBot(Client):
         if message[0] != config.COMMAND_PREFIX:
             return
         command, _, message = message[1:].partition(' ')
-        clean_command = command.lower().strip()
+        clean_command = command.split('@')[0].lower().strip()
         return clean_command, message
 
     def run_plugin(self, author_id, message, thread_id, thread_type, **kwargs):
@@ -71,6 +71,7 @@ class SteelyBot(Client):
                                   args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
         thread.deamon = True
         thread.start()
+        # TODO(iandioch): Record stat for plugin.
 
     def run_non_plugins(self, author_id, message, thread_id, thread_type, **kwargs):
         for plugin in self.non_plugins:

--- a/steely/telegram_fbchat_facade.py
+++ b/steely/telegram_fbchat_facade.py
@@ -1,3 +1,4 @@
+import difflib
 import json
 from collections import defaultdict, deque
 from enum import Enum
@@ -64,7 +65,8 @@ class SteelyUserManager:
             'full_name': info.full_name, # eg 'Noah Ó D'
             'username': info.username, # eg. 'iandioch'
         }
-        self.user_db.insert(data)
+        USER = Query()
+        self.user_db.upsert(data, USER.id == user_id)
 
     def get_user_info(self, user_id):
         print('SteelyUserManager: requested user info', user_id)
@@ -78,8 +80,10 @@ class SteelyUserManager:
 
     def search_for_users(self, name): 
         print('SteelyUserManager: searching for user:', name)
-        # TODO(iandioch): Find a closest user from the DB for full_name ~= name.
-        return []
+        print(self.user_db.all())
+        ans = max(self.user_db.all(),
+                  key=lambda x: difflib.SequenceMatcher(None, x['full_name'], name).ratio())
+        return ans
 
 
 class Client:


### PR DESCRIPTION
Fixes `/np milestone`, `/np collage`, `/np` (sometimes didn't work because markdown parsing failed, as the markdown parser is dumb and doesn't recognise URLs and the like)
Does some gex stuff
allows you to do `/np@steelybot` which is what Telegram sends by default if you hit the suggested command from the pop-up list after you start typing a command.
Adds TODO to fix `/stats`, which is just as good as an impl