### PR TITLE
Fix /stats so that Telegram gets command counts

### DIFF
--- a/steely/plugins/recordstat.py
+++ b/steely/plugins/recordstat.py
@@ -32,7 +32,8 @@ def looks_like_command(command):
 def is_command(command, plugins):
     if not looks_like_command(command):
         return False
-    stripped_command = (command[1:] if command[0] in COMMAND_IDENTIFIERS else command)
+    stripped_command = (command[1:] if command[0]
+                        in COMMAND_IDENTIFIERS else command)
     if stripped_command in plugins:
         return True
     elif is_tilda_command(command):

--- a/steely/plugins/recordstat.py
+++ b/steely/plugins/recordstat.py
@@ -12,6 +12,7 @@ CMD_DB = new_database('stats')
 CMD = Query()
 TILDA_DB = new_database('quote')
 TILDA = Query()
+COMMAND_IDENTIFIERS = set(['.', '~', '/'])
 
 
 def first_word_of(message):
@@ -25,14 +26,13 @@ def is_tilda_command(command):
 
 
 def looks_like_command(command):
-    identifiers = '.', '~', '/'
-    return any(command.startswith(char) for char in identifiers)
+    return any(command.startswith(char) for char in COMMAND_IDENTIFIERS)
 
 
 def is_command(command, plugins):
     if not looks_like_command(command):
         return False
-    stripped_command = (command[1:] if command[0] == '.' else command)
+    stripped_command = (command[1:] if command[0] in COMMAND_IDENTIFIERS else command)
     if stripped_command in plugins:
         return True
     elif is_tilda_command(command):

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -71,7 +71,6 @@ class SteelyBot(Client):
                                   args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
         thread.deamon = True
         thread.start()
-        # TODO(iandioch): Record stat for plugin.
 
     def run_non_plugins(self, author_id, message, thread_id, thread_type, **kwargs):
         for plugin in self.non_plugins:


### PR DESCRIPTION
`/stats` was previously broken on Telegram, as it turns out it was only recognising a valid command as being a message starting with `.`, but Telegram messages start with `/`. This PR fixes that so that /stats counts anything that looks like it might be a command. It's a bit overzealous (it'll count `...` and `~_~` as being commands too, IIUC), but better to overcount than undercount imo.