### PR TITLE
Fix /np list

### DIFF
--- a/steely/plugins/_lastfm_list.py
+++ b/steely/plugins/_lastfm_list.py
@@ -11,7 +11,7 @@ def parse_onlines(async_responses):
         response = async_response.result()
         try:
             latest_track_obj = response.json()["recenttracks"]["track"][0]
-        except IndexError:
+        except (IndexError, KeyError):
             yield False
         else:
             yield "@attr" in latest_track_obj and \


### PR DESCRIPTION
`/np list` was failing because the key `recenttracks` didn't exist in the response JSON. Adding `KeyError` to this `except` clause handles that.

`IndexError` must also be caught, in order to handle the case where `response.json()['recenttracks']['track']` doesn't have a 0'th element.