### PR TITLE
Shush some errors & fix /xkcd

### DIFF
--- a/steely/plugins/xkcd.py
+++ b/steely/plugins/xkcd.py
@@ -12,5 +12,6 @@ def main(bot, author_id, message, thread_id, thread_type, **kwargs):
     response = requests.get("https://xkcd.com/info.0.json")
     image = response.json()['img']
     message = response.json()['alt']
-    bot.sendRemoteImage(image, message=message,
+    bot.sendRemoteImage(image,
                         thread_id=thread_id, thread_type=thread_type)
+    bot.sendMessage(message, thread_id=thread_id, thread_type=thread_type)

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -83,6 +83,9 @@ class SteelyBot(Client):
     def onMessage(self, author_id, message, thread_id, thread_type, **kwargs):
         if author_id == self.uid:
             return
+        if message is None or message == '':
+            # May occur when an image or sticker is sent.
+            return
         self.run_non_plugins(author_id, message, thread_id,
                              thread_type, **kwargs)
         self.run_plugin(author_id, message, thread_id, thread_type, **kwargs)


### PR DESCRIPTION
- Fix `/xkcd` so it works with telegram
- Do not try to trigger plugins for a text-less message, so that there aren't 10 errors printed any time someone posts an image.