### PR TITLE
Add new decorator-based plugin config system, and an example plugin using it: /nw

### DIFF
--- a/steely/plugin.py
+++ b/steely/plugin.py
@@ -11,8 +11,11 @@ class PluginManager:
         # assumes "command" does not start with "/". Eg., for "/np top 7day", "command" would be "np top 7day"
         # returns longest matching command and a func to be called against "command"
 
+        command = command.lower().strip()
         print('Finding longest match for "/{}".'.format(command))
         print('Active listeners:', ', '.join(cls._command_listeners.keys()))
+
+        # TODO(iandioch): Should fix the bug where "/np helperson" would yield "/np help" instead of giving "/np" for user "helperson"
         longest_matching_listener = None
         longest_match = 0
         for command_listener in cls._command_listeners:
@@ -32,7 +35,7 @@ class PluginManager:
     def add_listener_for_command(cls, command, func):
         if command in cls._command_listeners:
             raise KeyError('Tried to add listener for command "{}", but one already exists.'.format(command))
-        cls._command_listeners[command] = func
+        cls._command_listeners[command.lower().strip()] = func
 
     @staticmethod
     def load_plugins():

--- a/steely/plugin.py
+++ b/steely/plugin.py
@@ -9,7 +9,7 @@ class PluginManager:
     @classmethod
     def get_listener_for_command(cls, command):
         # assumes "command" does not start with "/". Eg., for "/np top 7day", "command" would be "np top 7day"
-        # returns a func to be called against "command"
+        # returns longest matching command and a func to be called against "command"
 
         print('Finding longest match for "/{}".'.format(command))
         print('Active listeners:', ', '.join(cls._command_listeners.keys()))
@@ -19,8 +19,10 @@ class PluginManager:
             if command.startswith(command_listener):
                 if len(command_listener) > longest_match:
                     longest_match = len(command_listener)
-                    longest_matching_listener = cls._command_listeners[command_listener]
-        return longest_matching_listener
+                    longest_matching_listener = command_listener
+        if longest_matching_listener is None:
+            return None, None
+        return longest_matching_listener, cls._command_listeners[longest_matching_listener]
 
     @classmethod
     def add_passive_listener(cls, func):

--- a/steely/plugin.py
+++ b/steely/plugin.py
@@ -32,6 +32,10 @@ class PluginManager:
             raise KeyError('Tried to add listener for command "{}", but one already exists.'.format(command))
         cls._command_listeners[command] = func
 
+    @staticmethod
+    def load_plugins():
+        import plugins.letterboxd.main
+
 
 class Plugin:
     def __init__(self, name, author, help):
@@ -89,3 +93,6 @@ class Plugin:
 
 def create_plugin(name=None, author=None, help=None):
     return Plugin(name, author, help)
+
+if __name__ == '__main__':
+    PluginManager.load_plugins()

--- a/steely/plugin.py
+++ b/steely/plugin.py
@@ -1,0 +1,91 @@
+class PluginManager:
+    _command_listeners = {}
+    _passive_listeners = []
+
+    @classmethod
+    def get_passive_listeners(cls):
+        return cls._passive_listeners
+
+    @classmethod
+    def get_listener_for_command(cls, command):
+        # assumes "command" does not start with "/". Eg., for "/np top 7day", "command" would be "np top 7day"
+        # returns a func to be called against "command"
+
+        print('Finding longest match for "/{}".'.format(command))
+        print('Active listeners:', ', '.join(cls._command_listeners.keys()))
+        longest_matching_listener = None
+        longest_match = 0
+        for command_listener in cls._command_listeners:
+            if command.startswith(command_listener):
+                if len(command_listener) > longest_match:
+                    longest_match = len(command_listener)
+                    longest_matching_listener = cls._command_listeners[command_listener]
+        return longest_matching_listener
+
+    @classmethod
+    def add_passive_listener(cls, func):
+        cls._passive_listeners.append(func)
+
+    @classmethod
+    def add_listener_for_command(cls, command, func):
+        if command in cls._command_listeners:
+            raise KeyError('Tried to add listener for command "{}", but one already exists.'.format(command))
+        cls._command_listeners[command] = func
+
+
+class Plugin:
+    def __init__(self, name, author, help):
+        self.name = name
+        self.author = author
+        self.help = help
+        # .active decides whether the plugin is available to be used.
+        self.active = True
+
+    def setup(self):
+        # TODO(iandioch): Right now, this decorator must be run like the following:
+        # @setup()
+        # def setup_func():
+        #   ...
+        # 
+        # However, it should also be possible to run it without the brackets after @setup,
+        # as a naked decorator.
+        def wrapper(func):
+            try:
+                result = func()
+                if result is not None:
+                    print('Received error while running setup for plugin "{}":\n{}.'.format(self.name, result)) 
+                    print(self.name)
+                    self.active = False
+            except Exception as e:
+                print('Error thrown while running setup for plugin "{}":\n{}.'.format(self.name, e))
+                self.active = False
+            return func
+
+
+        print('active?', self.active)
+        #TODO(iandioch): Add the helpstring so that '/help name' might work.
+        #TODO(iandioch): Consider the fact that "name" and the specific listed commands might be different.
+        #TODO(iandioch): Consider that someone shouldn't have to repeat the same root command for all different @plugin.listen() methods in that plugin.
+        return wrapper 
+
+    def listen(self, command=None):
+        # TODO(iandioch): Make it possible to run this as a naked decorator for plugins that are passively listening.
+        if not self.active:
+            print('Tried to set up listener "{}" for plugin "{}", but plugin is not active.'.format(command, self.name))
+            # Return a do-nothing decorator, as we don't want to register this command.
+            return lambda _: None
+
+        print('Adding command "{}" to plugin "{}" by "{}".'.format(command, self.name, self.author))
+        #TODO(iandioch): Add functools.wraps() to update __name__, etc.
+        def register_listener(func):
+            if command is None:
+                PluginManager.add_passive_listener(func)
+            else:
+                PluginManager.add_listener_for_command(command, func)
+
+            return func
+        return register_listener 
+
+
+def create_plugin(name=None, author=None, help=None):
+    return Plugin(name, author, help)

--- a/steely/plugin.py
+++ b/steely/plugin.py
@@ -1,6 +1,142 @@
+from enum import Enum
+
+
+class CommandPartType(Enum):
+    # A subcommand, eg. the token "set" in "/np set <username>".
+    SUBCOMMAND = 1
+    # A required argument to the command, eg. "<username>" in "/np set
+    # <username>". Required arguments are denoted by some token surrounded by
+    # <pointy brackets>. In this example, that CommandPart will have the name
+    # "username".
+    REQUIRED_ARGUMENT = 2
+    # An optional argument to the command, eg. the token "[username]" in "/np
+    # [username]". Optional arguments are denoted by some token surrounded by
+    # [square brackets]. In this example, that CommandPart will have the name
+    # "username".
+    OPTIONAL_ARGUMENT = 3
+
+
+class PluginCommand:
+
+    class CommandPart:
+
+        def __init__(self, _str):
+            self._str = _str
+            # TODO(iandioch): Handle zero-len strings edge case
+            if _str[0] == '<' and _str[-1] == '>':
+                self.type = CommandPartType.REQUIRED_ARGUMENT
+                self.name = _str[1:-1]
+            elif _str[0] == '[' and _str[-1] == ']':
+                # Optional arg
+                self.type = CommandPartType.OPTIONAL_ARGUMENT
+                self.name = _str[1:-1]
+            else:
+                self.type = CommandPartType.SUBCOMMAND
+                self.name = _str
+
+    def __init__(self, command, func):
+        self.command = command
+        self.func = func
+
+        self.command_parts = self._parse_defined_command_parts(command)
+
+    def _parse_defined_command_parts(self, command_str):
+        parts = command_str.split(' ')
+        return [PluginCommand.CommandPart(part) for part in parts]
+
+    def _parse_command_call(self, expected_command_parts, called_command_parts):
+        # Returns the number of matched parts, the string length matched, and a
+        # dict of the parsed args.
+        parsed_args = {}
+        i = 0
+        str_match_len = 0
+        while i < len(expected_command_parts) and i < len(called_command_parts):
+            expected_part = expected_command_parts[i]
+            if expected_part.type is CommandPartType.SUBCOMMAND:
+                # Required str, must match exactly.
+                if called_command_parts[i] == expected_part.name:
+                    str_match_len += len(called_command_parts[i])
+                    i += 1
+                    continue
+                else:
+                    # Expected some specific str, got something else, abort.
+                    return 0, 0, {}
+
+            elif expected_part.type is CommandPartType.REQUIRED_ARGUMENT:
+                parsed_args[expected_part.name] = called_command_parts[i]
+                str_match_len += len(called_command_parts[i])
+                i += 1
+
+            elif expected_part.type is CommandPartType.OPTIONAL_ARGUMENT:
+                # If the expected command is "/help [search_str] <topic>" to
+                # yield only the part of the helpstring for "topic" relevant to
+                # "search_str", and the called command is "/help jamiroquai",
+                # then decide if we should count "jamiroquai" as a search_str
+                # or as a topic for a better overall match.
+                print('Trying to match part "{}" against optional command "{}".'.format(
+                    called_command_parts[i], expected_command_parts[i].name))
+
+                i_matched, len_matched, args_matched = self._parse_command_call(
+                    expected_command_parts[i + 1:], called_command_parts[i + 1:])
+                len_matched += len(called_command_parts[i])
+                args_matched[expected_command_parts[
+                    i].name] = called_command_parts[i]
+                print('If matched: ({}, {}, {})'.format(
+                    i_matched, len_matched, args_matched))
+
+                i_not_matched, len_not_matched, args_not_matched = self._parse_command_call(
+                    expected_command_parts[i + 1:], called_command_parts[i:])
+                print('If not matched: ({}, {}, {})'.format(
+                    i_not_matched, len_not_matched, args_not_matched))
+
+                # Choose whether matching or not matching this optional argument
+                # creates a better overall match for the string...
+                best_match_i = i_not_matched
+                best_match_len = len_not_matched
+                best_matched_args = args_not_matched
+                if i_matched >= i_not_matched:
+                    print('Matching "{}" against "{}" is better than not.'.format(
+                        called_command_parts[i], expected_command_parts[i].name))
+                    best_match_i = i_matched
+                    best_match_len = len_matched
+                    best_matched_args = args_matched
+
+                print(best_match_i, best_matched_args)
+
+                # We must add + here because the optional arg was matched either
+                # way, as it is optional...
+                i += best_match_i + 1
+                parsed_args.update(best_matched_args)
+                str_match_len += best_match_len
+
+        # If we reached the end of the input string and there is still something
+        # expected that _must_ be matched, then this avenue is useless, return
+        # no match.
+        if i < len(expected_command_parts):
+            for other_expected_part in expected_command_parts[i:]:
+                if other_expected_part.type in [CommandPartType.REQUIRED_ARGUMENT,
+                                                CommandPartType.SUBCOMMAND]:
+                    print('Reached end of command call str, but no match found for "{}".'.format(
+                        other_expected_part.name))
+                    return 0, 0, {}
+
+        # We don't want i to ever be greater than len(expected_command_parts)...
+        # Not that this should happen.
+        i = min(i, len(expected_command_parts))
+
+        print('Matched {} parts for call "{}" in plugin "{}"'.format(
+            i, called_command_parts, self.command))
+        print('This has matched args: ', parsed_args)
+        return i, str_match_len, parsed_args
+
+    def get_best_match(self, called_command_parts):
+        # Returns (parts matched, str length of match, matched args dict)
+        return self._parse_command_call(self.command_parts, called_command_parts)
+
+
 class PluginManager:
-    _command_listeners = {}
-    _passive_listeners = []
+    _command_listeners = []  # A list of PluginCommands.
+    _passive_listeners = []  # A list of plain funcs.
 
     @classmethod
     def get_passive_listeners(cls):
@@ -9,23 +145,49 @@ class PluginManager:
     @classmethod
     def get_listener_for_command(cls, command):
         # assumes "command" does not start with "/". Eg., for "/np top 7day", "command" would be "np top 7day"
-        # returns longest matching command and a func to be called against "command"
+        # returns longest matching command and a func to be called against
+        # "command"
 
         command = command.lower().strip()
         print('Finding longest match for "/{}".'.format(command))
-        print('Active listeners:', ', '.join(cls._command_listeners.keys()))
+        print('Active listeners:', ', '.join(
+            c.command for c in cls._command_listeners))
 
-        # TODO(iandioch): Should fix the bug where "/np helperson" would yield "/np help" instead of giving "/np" for user "helperson"
+        command_parts = command.split(' ')
+
+        # TODO(iandioch): Should fix the bug where "/np helperson" would yield
+        # "/np help" instead of giving "/np" for user "helperson"
         longest_matching_listener = None
         longest_match = 0
-        for command_listener in cls._command_listeners:
-            if command.startswith(command_listener):
-                if len(command_listener) > longest_match:
-                    longest_match = len(command_listener)
-                    longest_matching_listener = command_listener
-        if longest_matching_listener is None:
-            return None, None
-        return longest_matching_listener, cls._command_listeners[longest_matching_listener]
+
+        best_match_num_parts = 0
+        best_match_str_len = 0
+        best_match_args = {}
+        best_match_plugin = None
+
+        for plugin_command in cls._command_listeners:
+            num_parts, str_len, args = plugin_command.get_best_match(
+                command_parts)
+            if (num_parts > best_match_num_parts) or (num_parts == best_match_num_parts and str_len > best_match_str_len):
+                best_match_num_parts = num_parts
+                best_match_str_len = str_len
+                best_match_args = args
+                best_match_plugin = plugin_command
+
+        if best_match_plugin is None:
+            print('No best matching plugin found for call "{}"'.format(command))
+            return None, None, None
+
+        # The + best_match_num_parts - 1 part of this is required to account for
+        # the spaces between command parts that are matched but never added
+        # anywhere before.
+        total_str_match_len = best_match_str_len + best_match_num_parts - 1
+
+        print('Best matching plugin for call "{}" is "{}", with args: {}'.format(
+            command, best_match_plugin.command, best_match_args))
+        print('This matches {} parts, with prefix substr "{}".'.format(
+            best_match_num_parts, command[:total_str_match_len]))
+        return command[:total_str_match_len], best_match_plugin.func, best_match_args
 
     @classmethod
     def add_passive_listener(cls, func):
@@ -33,9 +195,7 @@ class PluginManager:
 
     @classmethod
     def add_listener_for_command(cls, command, func):
-        if command in cls._command_listeners:
-            raise KeyError('Tried to add listener for command "{}", but one already exists.'.format(command))
-        cls._command_listeners[command.lower().strip()] = func
+        cls._command_listeners.append(PluginCommand(command, func))
 
     @staticmethod
     def load_plugins():
@@ -43,49 +203,59 @@ class PluginManager:
 
 
 class Plugin:
+
     def __init__(self, name, author, help):
         self.name = name
         self.author = author
         self.help = help
         # .active decides whether the plugin is available to be used.
         self.active = True
+        self.commands = []
 
     def setup(self):
         # TODO(iandioch): Right now, this decorator must be run like the following:
         # @setup()
         # def setup_func():
         #   ...
-        # 
+        #
         # However, it should also be possible to run it without the brackets after @setup,
         # as a naked decorator.
         def wrapper(func):
             try:
                 result = func()
                 if result is not None:
-                    print('Received error while running setup for plugin "{}":\n{}.'.format(self.name, result)) 
+                    print('Received error while running setup for plugin "{}":\n{}.'.format(
+                        self.name, result))
                     print(self.name)
                     self.active = False
             except Exception as e:
-                print('Error thrown while running setup for plugin "{}":\n{}.'.format(self.name, e))
+                print('Error thrown while running setup for plugin "{}":\n{}.'.format(
+                    self.name, e))
                 self.active = False
             return func
 
-
         print('active?', self.active)
-        #TODO(iandioch): Add the helpstring so that '/help name' might work.
-        #TODO(iandioch): Consider the fact that "name" and the specific listed commands might be different.
-        #TODO(iandioch): Consider that someone shouldn't have to repeat the same root command for all different @plugin.listen() methods in that plugin.
-        return wrapper 
+        # TODO(iandioch): Add the helpstring so that '/help name' might work.
+        # TODO(iandioch): Consider the fact that "name" and the specific listed commands might be different.
+        # TODO(iandioch): Consider that someone shouldn't have to repeat the
+        # same root command for all different @plugin.listen() methods in that
+        # plugin.
+        return wrapper
 
     def listen(self, command=None):
-        # TODO(iandioch): Make it possible to run this as a naked decorator for plugins that are passively listening.
+        # TODO(iandioch): Make it possible to run this as a naked decorator for
+        # plugins that are passively listening.
         if not self.active:
-            print('Tried to set up listener "{}" for plugin "{}", but plugin is not active.'.format(command, self.name))
-            # Return a do-nothing decorator, as we don't want to register this command.
+            print('Tried to set up listener "{}" for plugin "{}", but plugin is not active.'.format(
+                command, self.name))
+            # Return a do-nothing decorator, as we don't want to register this
+            # command.
             return lambda _: None
 
-        print('Adding command "{}" to plugin "{}" by "{}".'.format(command, self.name, self.author))
-        #TODO(iandioch): Add functools.wraps() to update __name__, etc.
+        print('Adding command "{}" to plugin "{}" by "{}".'.format(
+            command, self.name, self.author))
+        # TODO(iandioch): Add functools.wraps() to update __name__, etc.
+
         def register_listener(func):
             if command is None:
                 PluginManager.add_passive_listener(func)
@@ -93,7 +263,13 @@ class Plugin:
                 PluginManager.add_listener_for_command(command, func)
 
             return func
-        return register_listener 
+
+        if command is not None:
+            print('Adding command {} to list for plugin {}'.format(
+                command, self.name))
+            self.commands.append(command)
+
+        return register_listener
 
 
 def create_plugin(name=None, author=None, help=None):

--- a/steely/plugin.py
+++ b/steely/plugin.py
@@ -286,6 +286,9 @@ class Plugin:
     Required arguments can be included surrounded by <angle brackets>. Eg.
     @plugin.listen(command='/roll <dice_string>')
 
+    All patterns (subcommands or arguments) are assumed to be single tokens (ie.
+    single words) in a single-space-delimited string.
+
     If no 'command' argument is given to @plugin.listen(), the function will be
     considered a passive listener, and will be triggered for every message sent
     to a channel the bot is active in. Eg.:

--- a/steely/plugins/letterboxd/main.py
+++ b/steely/plugins/letterboxd/main.py
@@ -59,12 +59,11 @@ def plugin_setup():
     USERDB = new_database('letterboxd')
 
 
-@plugin.listen(command='nw')
+@plugin.listen(command='nw [username]')
 def root_command(bot, author_id, message, thread_id, thread_type, **kwargs):
-    message_parts = message.split(' ')
     user = USERDB.get(USER.id == author_id)
-    if message_parts and len(message_parts[0]):
-        username = message_parts[0]
+    if 'username' in kwargs:
+        username = kwargs['username'] 
     elif user:
         username = user['username']
     else:
@@ -81,23 +80,24 @@ def root_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     bot.sendMessage(f"{username} added {italic(title)} on {date_str}\n{url}", thread_id=thread_id, thread_type=thread_type)
 
 
-@plugin.listen(command='nw set')
+@plugin.listen(command='nw set <username>')
 def set_command(bot, author_id, message, thread_id, thread_type, **kwargs):
-    if not message or not len(message):
+    if 'username' not in kwargs or not len(kwargs['username']):
         bot.sendMessage('no username provided', thread_id=thread_id,
                         thread_type=thread_type)
         return
-    username = message.split(' ')[0]
+    username = kwargs['username']
     if not USERDB.search(USER.id == author_id):
         USERDB.insert({'id': author_id, 'username': username})
-        bot.sendMessage('good egg', thread_id=thread_id,
+        bot.sendMessage('good egg, you\'re now {}'.format(username), thread_id=thread_id,
                         thread_type=thread_type)
     else:
         USERDB.update({'username': username}, USER.id == author_id)
-        bot.sendMessage('updated egg', thread_id=thread_id,
+        bot.sendMessage('updated egg, you\'re now {}'.format(username), thread_id=thread_id,
                         thread_type=thread_type)
 
 
 @plugin.listen(command='nw help')
 def help_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     bot.sendMessage(plugin.help, thread_id=thread_id, thread_type=thread_type)
+    bot.sendMessage('\n'.join(("/" + command) for command in plugin.commands), thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/letterboxd/main.py
+++ b/steely/plugins/letterboxd/main.py
@@ -1,24 +1,41 @@
 from plugin import create_plugin, PluginManager
+from utils import new_database
+from tinydb import Query
 
 plugin = create_plugin(name='nw', author='iandioch', help='todo')
 
+USERDB = None
+USER = Query()
+LETTERBOXD_RSS_ADDRESS = 'https://letterboxd.com/{}/rss/'
+rss = None
+
 @plugin.setup()
 def plugin_setup():
-    # TODO(iandioch): Set up/load a DB of registered usernames.
-    return
+    global USERDB, rss
+    import feedparser
+    rss = feedparser
+
+    USERDB = new_database('letterboxd')
 
 @plugin.listen(command='nw')
 def root_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     print(author_id, message)
 
+@plugin.listen(command='nw set')
+def set_command(bot, author_id, message, thread_id, thread_type, **kwargs):
+    if not message or not len(message):
+        print('no username provided.')
+        return
+    username = message.split(' ')[0]
+    if not USERDB.search(USER.id == author_id):
+        USERDB.insert({'id': author_id, 'username': username})
+        bot.sendMessage('good egg', thread_id=thread_id,
+                        thread_type=thread_type)
+    else:
+        USERDB.update({'username': username}, USER.id == author_id)
+        bot.sendMessage('updated egg', thread_id=thread_id,
+                        thread_type=thread_type)
+
 @plugin.listen(command='nw help')
 def help_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     bot.sendMessage(plugin.help, thread_id=thread_id, thread_type=thread_type)
-
-
-nw_command = PluginManager.get_listener_for_command('nw')
-if nw_command:
-    print('running "/nw"')
-    nw_command(None, 1234, 'message', 5678, 91011)
-else:
-    print('no command found for "/nw"')

--- a/steely/plugins/letterboxd/main.py
+++ b/steely/plugins/letterboxd/main.py
@@ -1,0 +1,24 @@
+from plugin import create_plugin, PluginManager
+
+plugin = create_plugin(name='nw', author='iandioch', help='todo')
+
+@plugin.setup()
+def plugin_setup():
+    # TODO(iandioch): Set up/load a DB of registered usernames.
+    return
+
+@plugin.listen(command='nw')
+def root_command(bot, author_id, message, thread_id, thread_type, **kwargs):
+    print(author_id, message)
+
+@plugin.listen(command='nw help')
+def help_command(bot, author_id, message, thread_id, thread_type, **kwargs):
+    bot.sendMessage(plugin.help, thread_id=thread_id, thread_type=thread_type)
+
+
+nw_command = PluginManager.get_listener_for_command('nw')
+if nw_command:
+    print('running "/nw"')
+    nw_command(None, 1234, 'message', 5678, 91011)
+else:
+    print('no command found for "/nw"')

--- a/steely/plugins/letterboxd/main.py
+++ b/steely/plugins/letterboxd/main.py
@@ -5,7 +5,10 @@ from paths import CONFIG
 from formatting import *
 import requests
 
-plugin = create_plugin(name='nw', author='iandioch', help='todo')
+HELP_STR = """'Now Watching' command, to give info on what films someone has
+recently watched, based on letterboxd.com activity."""
+
+plugin = create_plugin(name='nw', author='iandioch', help=HELP_STR)
 
 USERDB = None
 USER = Query()
@@ -63,7 +66,7 @@ def plugin_setup():
 def root_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     user = USERDB.get(USER.id == author_id)
     if 'username' in kwargs:
-        username = kwargs['username'] 
+        username = kwargs['username']
     elif user:
         username = user['username']
     else:
@@ -77,7 +80,8 @@ def root_command(bot, author_id, message, thread_id, thread_type, **kwargs):
                         thread_id=thread_id, thread_type=thread_type)
         return
 
-    bot.sendMessage(f"{username} added {italic(title)} on {date_str}\n{url}", thread_id=thread_id, thread_type=thread_type)
+    bot.sendMessage(f"{username} added {italic(title)} on {date_str}\n{url}",
+                    thread_id=thread_id, thread_type=thread_type)
 
 
 @plugin.listen(command='nw set <username>')
@@ -89,15 +93,18 @@ def set_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     username = kwargs['username']
     if not USERDB.search(USER.id == author_id):
         USERDB.insert({'id': author_id, 'username': username})
-        bot.sendMessage('good egg, you\'re now {}'.format(username), thread_id=thread_id,
+        bot.sendMessage('good egg, you\'re now {}'.format(username),
+                        thread_id=thread_id,
                         thread_type=thread_type)
     else:
         USERDB.update({'username': username}, USER.id == author_id)
-        bot.sendMessage('updated egg, you\'re now {}'.format(username), thread_id=thread_id,
+        bot.sendMessage('updated egg, you\'re now {}'.format(username),
+                        thread_id=thread_id,
                         thread_type=thread_type)
 
 
 @plugin.listen(command='nw help')
 def help_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     bot.sendMessage(plugin.help, thread_id=thread_id, thread_type=thread_type)
-    bot.sendMessage('\n'.join(("/" + command) for command in plugin.commands), thread_id=thread_id, thread_type=thread_type)
+    bot.sendMessage('\n'.join(("/" + command) for command in plugin.commands),
+                    thread_id=thread_id, thread_type=thread_type)

--- a/steely/plugins/letterboxd/main.py
+++ b/steely/plugins/letterboxd/main.py
@@ -1,6 +1,9 @@
 from plugin import create_plugin, PluginManager
 from utils import new_database
 from tinydb import Query
+from paths import CONFIG
+from formatting import *
+import requests
 
 plugin = create_plugin(name='nw', author='iandioch', help='todo')
 
@@ -8,6 +11,44 @@ USERDB = None
 USER = Query()
 LETTERBOXD_RSS_ADDRESS = 'https://letterboxd.com/{}/rss/'
 rss = None
+
+
+def absolute_short_url(relative):
+    return CONFIG.FLASKNASC_HOST + relative
+
+
+def maybe_get_short_url(long_url):
+    try:
+        params = {
+            'key': CONFIG.FLASKNASC_KEY,
+            'address': long_url
+        }
+        path = CONFIG.FLASKNASC_HOST + "/new/" + CONFIG.FLASKNASC_USER
+        response = requests.get(path, params=params)
+        return absolute_short_url(response.text)
+    except requests.exceptions.ConnectionError as e:
+        print('Error while trying to shorten URL for .np:')
+        print(e)
+        return long_url
+
+
+def get_most_recent_film(username):
+    print('Getting most recent film for {}'.format(username))
+    # TODO(iandioch): This returns the first thing in the feed, based on
+    # <pubDate> (when the user added it), not based on
+    # <letterboxd:watchedDate> (when the user specified they watched it).
+    feed = rss.parse(LETTERBOXD_RSS_ADDRESS.format(username))
+    if not len(feed.entries):
+        return None, None, None
+    item = feed.entries[0]
+    url = maybe_get_short_url(item.link)
+    title = item.title  # includes film title, year, and maybe a 1-5 star review
+    desc = item.description  # includes either watch date, or fuller text review
+    date_parts = item.published_parsed
+    date_str = '{}/{}/{}'.format(date_parts.tm_year,
+                                 date_parts.tm_mon, date_parts.tm_mday)
+    return title, date_str, url
+
 
 @plugin.setup()
 def plugin_setup():
@@ -17,14 +58,34 @@ def plugin_setup():
 
     USERDB = new_database('letterboxd')
 
+
 @plugin.listen(command='nw')
 def root_command(bot, author_id, message, thread_id, thread_type, **kwargs):
-    print(author_id, message)
+    message_parts = message.split(' ')
+    user = USERDB.get(USER.id == author_id)
+    if message_parts and len(message_parts[0]):
+        username = message_parts[0]
+    elif user:
+        username = user['username']
+    else:
+        bot.sendMessage(f'include username please or use `/nw set`',
+                        thread_id=thread_id, thread_type=thread_type)
+        return
+
+    title, date_str, url = get_most_recent_film(username)
+    if title is None:
+        bot.sendMessage(f'Could not load most recent film for {username}.',
+                        thread_id=thread_id, thread_type=thread_type)
+        return
+
+    bot.sendMessage(f"{username} added {italic(title)} on {date_str}\n{url}", thread_id=thread_id, thread_type=thread_type)
+
 
 @plugin.listen(command='nw set')
 def set_command(bot, author_id, message, thread_id, thread_type, **kwargs):
     if not message or not len(message):
-        print('no username provided.')
+        bot.sendMessage('no username provided', thread_id=thread_id,
+                        thread_type=thread_type)
         return
     username = message.split(' ')[0]
     if not USERDB.search(USER.id == author_id):
@@ -35,6 +96,7 @@ def set_command(bot, author_id, message, thread_id, thread_type, **kwargs):
         USERDB.update({'username': username}, USER.id == author_id)
         bot.sendMessage('updated egg', thread_id=thread_id,
                         thread_type=thread_type)
+
 
 @plugin.listen(command='nw help')
 def help_command(bot, author_id, message, thread_id, thread_type, **kwargs):

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -68,10 +68,10 @@ class SteelyBot(Client):
         command, message = parsed_message
 
         # Run plugins following SEP1 interface.
-        plugin = PluginManager.get_listener_for_command('{} {}'.format(command, message))
-        if plugin is not None:
+        matched_command, plugin = PluginManager.get_listener_for_command('{} {}'.format(command, message))
+        if matched_command is not None:
             thread = threading.Thread(target=plugin,
-                                      args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
+                    args=(self, author_id, message[len(matched_command)+1:], thread_id, thread_type), kwargs=kwargs)
             thread.deamon = True
             thread.start()
 

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -14,6 +14,7 @@ import random
 import requests
 import sys
 import threading
+import logging
 
 
 HELP_DOC = '''help <command>
@@ -112,6 +113,7 @@ class SteelyBot(Client):
 
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
     client = SteelyBot(config.EMAIL, config.TELEGRAM_KEY)
     while True:
         with suppress(requests.exceptions.ConnectionError):

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -68,10 +68,11 @@ class SteelyBot(Client):
         command, message = parsed_message
 
         # Run plugins following SEP1 interface.
-        matched_command, plugin = PluginManager.get_listener_for_command('{} {}'.format(command, message))
+        full_message = '{} {}'.format(command, message)
+        matched_command, plugin = PluginManager.get_listener_for_command(full_message)
         if matched_command is not None:
             thread = threading.Thread(target=plugin,
-                    args=(self, author_id, message[len(matched_command)+1:], thread_id, thread_type), kwargs=kwargs)
+                    args=(self, author_id, full_message[len(matched_command)+1:], thread_id, thread_type), kwargs=kwargs)
             thread.deamon = True
             thread.start()
 

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -69,10 +69,12 @@ class SteelyBot(Client):
 
         # Run plugins following SEP1 interface.
         full_message = '{} {}'.format(command, message)
-        matched_command, plugin = PluginManager.get_listener_for_command(full_message)
+        matched_command, plugin, args = PluginManager.get_listener_for_command(full_message)
         if matched_command is not None:
+            passed_kwargs = kwargs.copy()
+            passed_kwargs.update(args)
             thread = threading.Thread(target=plugin,
-                    args=(self, author_id, full_message[len(matched_command)+1:], thread_id, thread_type), kwargs=kwargs)
+                    args=(self, author_id, full_message[len(matched_command)+1:], thread_id, thread_type), kwargs=passed_kwargs)
             thread.deamon = True
             thread.start()
 

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -6,6 +6,7 @@ from telegram_fbchat_facade import log, Client
 from tinydb import TinyDB
 from vapor import vapor
 from utils import list_plugins
+from plugin import PluginManager
 import config
 import imp
 import os
@@ -35,6 +36,7 @@ class SteelyBot(Client):
         self.load_plugins()
 
     def load_plugins(self):
+        PluginManager.load_plugins()
         self.non_plugins = []
         self.plugins = {}
         self.plugin_helps = {
@@ -64,6 +66,16 @@ class SteelyBot(Client):
         if parsed_message is None:
             return
         command, message = parsed_message
+
+        # Run plugins following SEP1 interface.
+        plugin = PluginManager.get_listener_for_command('{} {}'.format(command, message))
+        if plugin is not None:
+            thread = threading.Thread(target=plugin,
+                                      args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
+            thread.deamon = True
+            thread.start()
+
+        # Run normal traditional steely plugins.
         if not command in self.plugins:
             return
         plugin = self.plugins[command]
@@ -80,12 +92,20 @@ class SteelyBot(Client):
             thread.deamon = True
             thread.start()
 
+        for plugin in PluginManager.get_passive_listeners():
+            thread = threading.Thread(target=plugin,
+                                      args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
+            thread.deamon = True
+            thread.start()
+
+
     def onMessage(self, author_id, message, thread_id, thread_type, **kwargs):
         if author_id == self.uid:
             return
         self.run_non_plugins(author_id, message, thread_id,
                              thread_type, **kwargs)
         self.run_plugin(author_id, message, thread_id, thread_type, **kwargs)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #138.

Nothing was agreed in #138, so I wrote https://docs.google.com/document/d/17gS_hrBiXDyB4UCvKRlNv9JvBVzerFQVQIS5AQboM5Y/edit, and then decided myself on an approach. If you have some problem with it, merge this PR then submit a change later, otherwise this PR will sit in limbo forever...

Known problems:
- Helpstrings aren't added to the global helpstring directory (yet...)
- There's Undefined Behaviour if a plugin using the new style is defined in a file directly below `/plugins`. I think it'll work fine, I just didn't try it.
- Part 4 of the doc above isn't implemented, but is mostly tangential anyway.
- There's lots of functionality of /nw that is missing / could be improved.
- I'd like to wrap the whole (bot, author_id, message, thread_id, thread_type) shindig in some nicer structure, but that can come another day.
- I haven't really tested command strings more complicated than what is in the `/nw` plugin, so I'm sure there's bugs if you have multiple optional arguments or required arguments after optional ones or whatever. I think this impl as it is covers the most common cases.
- There's nowhere to check if the arguments declared in the command string's names overlap each other or clash with the already-existing function args. ie. you could call your argument `thread_id` and might be in a pickle. Or you could declare `@plugin.listen(command='cmd <arg1> <arg1> <arg1>'), idk what the value of `arg1` would be at runtime....

This PR is mainly just trying to get the basics in, and then wee bits can be improved upon.

---

# SEP 1: A new frontier for dodgy steely plugins

See a minimal example of a new plugin here:

```python
plugin = Plugin("simon says", "iandioch", "run '/simon <your message here>' to get simon to say it")

@plugin.listen(command='simon')
def simon_says(bot, author_id, message, thread_id, thread_type, **kwargs):
    bot.sendMessage('simon says: ' + message), thread_id=thread_id, thread_type=thread_type)
```

A passive listener (I think the code calls them "non-plugins" in some places) can be declared by just leaving out the "command" arg in `@plugin.listen()`:

```python
plugin = Plugin("gotcha", "iandioch", "says gotcha a lot")

@plugin.listen()
def simon_says(bot, author_id, message, thread_id, thread_type, **kwargs):
    bot.sendMessage('gotcha', thread_id=thread_id, thread_type=thread_type)
```

You can also use the command string to declare what args your command needs:

```python
plugin = Plugin("say something", "iandioch", "says the word you ask for")

@plugin.listen(command='say <my_message>')
def simon_says(bot, author_id, message, thread_id, thread_type, **kwargs):
    bot.sendMessage(kwargs['my_message'], thread_id=thread_id, thread_type=thread_type)
```

`@plugin.setup()` is cool imo, and if used, brings many errors (missing dependencies, API keys missing from the config file, etc... these errors are pretty common) to startup time instead of plugin runtime. It also just prints a warning and doesn't include that plugin in the bot, instead of crashing the bot or whatever.

See the given letterboxd plugin for a proper example of the new API.

---

It'd be an eventual goal, after some little cleanups, to migrate existing plugins to the new format. After that, we will have completed #84. 