### PR TITLE
N/message interface

### DIFF
--- a/steely/message.py
+++ b/steely/message.py
@@ -1,0 +1,11 @@
+# TODO(iandioch): Migrate to python3.7 so we can annotate this with @dataclass
+class SteelyMessage:
+    """Class containing information about a single activity in a single channel.
+    Usually means a message with text was sent, but also could have been an
+    image sent (with no associated text message), etc."""
+
+    author_id: str
+    thread_id: str
+    thread_type: str
+    text: str
+    # TODO(iandioch): Add image_id.

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -7,6 +7,7 @@ from tinydb import TinyDB
 from vapor import vapor
 from utils import list_plugins
 from plugin import PluginManager
+from message import SteelyMessage
 import config
 import imp
 import os
@@ -102,15 +103,16 @@ class SteelyBot(Client):
             thread.start()
 
 
-    def onMessage(self, author_id, message, thread_id, thread_type, **kwargs):
-        if author_id == self.uid:
+    def onMessage(self, message: SteelyMessage):
+        if message.author_id == self.uid:
             return
-        if message is None or message == '':
+        if message.text is None or message.text == '':
             # May occur when an image or sticker is sent.
             return
-        self.run_non_plugins(author_id, message, thread_id,
-                             thread_type, **kwargs)
-        self.run_plugin(author_id, message, thread_id, thread_type, **kwargs)
+        self.run_non_plugins(message.author_id, message.text, message.thread_id,
+                             message.thread_type)
+        self.run_plugin(message.author_id, message.text, message.thread_id,
+                        message.thread_type)
 
 
 

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -63,20 +63,25 @@ class SteelyBot(Client):
         clean_command = command.split('@')[0].lower().strip()
         return clean_command, message
 
-    def run_plugin(self, author_id, message, thread_id, thread_type, **kwargs):
-        parsed_message = self.parse_command_message(message)
+    def run_plugin(self, message: SteelyMessage):
+        parsed_message = self.parse_command_message(message.text)
         if parsed_message is None:
             return
-        command, message = parsed_message
+        command, rest_of_message = parsed_message
 
         # Run plugins following SEP1 interface.
-        full_message = '{} {}'.format(command, message)
-        matched_command, plugin, args = PluginManager.get_listener_for_command(full_message)
+        full_message = '{} {}'.format(command, rest_of_message)
+        matched_command, plugin, args = PluginManager.get_listener_for_command(
+            full_message)
         if matched_command is not None:
-            passed_kwargs = kwargs.copy()
-            passed_kwargs.update(args)
             thread = threading.Thread(target=plugin,
-                    args=(self, author_id, full_message[len(matched_command)+1:], thread_id, thread_type), kwargs=passed_kwargs)
+                                      args=(self,
+                                            message.author_id,
+                                            full_message[
+                                                len(matched_command) + 1:],
+                                            message.thread_id,
+                                            message.thread_type),
+                                      kwargs=args)
             thread.deamon = True
             thread.start()
 
@@ -85,23 +90,37 @@ class SteelyBot(Client):
             return
         plugin = self.plugins[command]
         thread = threading.Thread(target=plugin.main,
-                                  args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
+                                  args=(self,
+                                        message.author_id,
+                                        message.text,
+                                        message.thread_id,
+                                        message.thread_type),
+                                  kwargs={})
         thread.deamon = True
         thread.start()
 
-    def run_non_plugins(self, author_id, message, thread_id, thread_type, **kwargs):
+    def run_non_plugins(self, message: SteelyMessage):
         for plugin in self.non_plugins:
             thread = threading.Thread(target=plugin.main,
-                                      args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
+                                      args=(self,
+                                            message.author_id,
+                                            message.text,
+                                            message.thread_id,
+                                            message.thread_type),
+                                      kwargs={})
             thread.deamon = True
             thread.start()
 
         for plugin in PluginManager.get_passive_listeners():
             thread = threading.Thread(target=plugin,
-                                      args=(self, author_id, message, thread_id, thread_type), kwargs=kwargs)
+                                      args=(self,
+                                            message.author_id,
+                                            message.text,
+                                            message.thread_id,
+                                            message.thread_type),
+                                      kwargs={})
             thread.deamon = True
             thread.start()
-
 
     def onMessage(self, message: SteelyMessage):
         if message.author_id == self.uid:
@@ -109,11 +128,8 @@ class SteelyBot(Client):
         if message.text is None or message.text == '':
             # May occur when an image or sticker is sent.
             return
-        self.run_non_plugins(message.author_id, message.text, message.thread_id,
-                             message.thread_type)
-        self.run_plugin(message.author_id, message.text, message.thread_id,
-                        message.thread_type)
-
+        self.run_non_plugins(message)
+        self.run_plugin(message)
 
 
 if __name__ == '__main__':

--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -9,6 +9,7 @@ from utils import list_plugins
 from plugin import PluginManager
 from message import SteelyMessage
 import config
+import copy
 import imp
 import os
 import random
@@ -74,13 +75,10 @@ class SteelyBot(Client):
         matched_command, plugin, args = PluginManager.get_listener_for_command(
             full_message)
         if matched_command is not None:
+            passed_message = copy.copy(message)
+            passed_message.text = full_message[len(matched_command) + 1:]
             thread = threading.Thread(target=plugin,
-                                      args=(self,
-                                            message.author_id,
-                                            full_message[
-                                                len(matched_command) + 1:],
-                                            message.thread_id,
-                                            message.thread_type),
+                                      args=(self, passed_message),
                                       kwargs=args)
             thread.deamon = True
             thread.start()
@@ -113,11 +111,7 @@ class SteelyBot(Client):
 
         for plugin in PluginManager.get_passive_listeners():
             thread = threading.Thread(target=plugin,
-                                      args=(self,
-                                            message.author_id,
-                                            message.text,
-                                            message.thread_id,
-                                            message.thread_type),
+                                      args=(self, message),
                                       kwargs={})
             thread.deamon = True
             thread.start()


### PR DESCRIPTION
Working towards #203.

The only visible change after this PR is that new plugins introduced in #215 take just (bot, message, **kwargs). But it means we can add new things (like image_url, sticker data, etc) that was included in messages, without changing the signature of any plugins... The new data can just be included in `SteelyMessage`.

I'm on the fence at also changing explicit /command calls to get some `CommandCall` obj containing the args and rest of message, instead of the args being added to `kwargs` and the `message.text` being (perhaps surprisingly?) a substring of the actually sent message. LMK if you have thoughts.