### PR TITLE
Fix all plugins except /nw

### DIFF
--- a/steely/steely_telegram.py
+++ b/steely/steely_telegram.py
@@ -90,7 +90,7 @@ class SteelyBot(Client):
         thread = threading.Thread(target=plugin.main,
                                   args=(self,
                                         message.author_id,
-                                        message.text,
+                                        rest_of_message,
                                         message.thread_id,
                                         message.thread_type),
                                   kwargs={})


### PR DESCRIPTION
Old-style commands expect the `message` arg to not contain the command call that triggered them, so `/np iandioch` should just send with `message="iandioch"`. With changes in #216, this (accidentally) changed. It's because all the variables were all called `message` :angry: 

This PR fixes my oopsie woopsie.